### PR TITLE
[CORE-5238] JSON encode params for database endpoint

### DIFF
--- a/intake_metabase/source.py
+++ b/intake_metabase/source.py
@@ -214,7 +214,7 @@ class MetabaseAPI():
         self._create_or_refresh_token()
 
         headers = _merge_dicts({'X-Metabase-Session': self._token}, self.extra_headers)
-        params = {'include': 'tables', 'saved': True}
+        params = json.dumps({'include': 'tables', 'saved': True})
 
         res = requests.get(
             urljoin(self.domain, '/api/database'),


### PR DESCRIPTION
Started seeing this error for `get_databases()` in our Metabase Open Source Edition instance after upgrading from [`v0.46.6.4`](https://github.com/metabase/metabase/releases/tag/v0.46.6.4) to [`v0.47.2`](https://github.com/metabase/metabase/releases/tag/v0.47.2)

<img width="827" alt="metabase-api_params" src="https://github.com/ContinuumIO/intake-metabase/assets/409842/d6c316e2-9ba6-41a5-852e-6f771a7c06ad">
