### PR TITLE
[CORE-5238] Use string for database endpoint params

### DIFF
--- a/intake_metabase/source.py
+++ b/intake_metabase/source.py
@@ -214,7 +214,7 @@ class MetabaseAPI():
         self._create_or_refresh_token()
 
         headers = _merge_dicts({'X-Metabase-Session': self._token}, self.extra_headers)
-        params = json.dumps({'include': 'tables', 'saved': True})
+        params = {'include': 'tables', 'saved': 'true'}
 
         res = requests.get(
             urljoin(self.domain, '/api/database'),


### PR DESCRIPTION
JSON encoding the params resulted in URL encoded JSON object in query string sent to the Metabase API.

* Followup to #8

The requests package [expects a dictionary of strings](https://docs.python-requests.org/en/latest/user/quickstart/#passing-parameters-in-urls) for `params` with no rules to encode boolean types [2, 3], so best to keep it simple and use strings.

* https://github.com/psf/requests/issues/2999
* https://github.com/psf/requests/issues/3355

<img width="787" alt="metabase-api_params_string" src="https://github.com/ContinuumIO/intake-metabase/assets/409842/3b8ba465-005a-4f3f-af0f-28f454a8e7c4">
